### PR TITLE
Add `home` view and `teacher default` view

### DIFF
--- a/fe/e2e/app.e2e-spec.ts
+++ b/fe/e2e/app.e2e-spec.ts
@@ -14,24 +14,69 @@ describe('Front-end of the elle app', () => {
       .then(done, done.fail);
   });
 
-  it('should only display the title when the screen is < 700px wide', done => {
-    page.setWidth(699);
-    page.getTextFrom('app-header h1')
-      .then(t => expect(t).toEqual('elle'))
-      .then(done, done.fail);
+  describe('Header component', () => {
+    beforeEach(() => {
+      page = new Page();
+      page.go('/');
+    });
+
+    it('should only display the title when the screen is < 700px wide', done => {
+      page.setWidth(699);
+      page.getTextFrom('app-header h1')
+        .then(t => expect(t).toEqual('elle'))
+        .then(done, done.fail);
+    });
+
+    it('should display `elle english language learning engine` when the screen is >= 700px wide', done => {
+      // media queries are a bit finicky here, so allow some `wiggle room`
+      page.setWidth(710);
+      page.getTextFrom('app-header h1')
+        .then(t => expect(t).toEqual('elle english language learning engine'))
+        .then(done, done.fail);
+    });
+
+    it('should display `Sign Up`, and `Sign In` in the menu', done => {
+      page.getTextFrom('app-header .header-nav')
+        .then(t => expect(t).toEqual('Sign up\nSign in'))
+        .then(done, done.fail);
+    });
   });
 
-  it('should display `elle english language learning engine` when the screen is >= 700px wide', done => {
-    // media queries are a bit finicky here, so allow some `wiggle room`
-    page.setWidth(710);
-    page.getTextFrom('app-header h1')
-      .then(t => expect(t).toEqual('elle english language learning engine'))
-      .then(done, done.fail);
+  describe('Home component', () => {
+    beforeEach(() => {
+      page = new Page();
+      page.go('/');
+    });
+
+    it('should prompt user to sign up or sign in', done => {
+      page.getTextFrom('app-home')
+        .then(t => expect(t).toBe('Please Sign Up or Sign In to get started'))
+        .then(done, done.fail);
+    });
   });
 
-  it('should display `Sign Up`, and `Sign In` in the menu', done => {
-    page.getTextFrom('.header-nav')
-      .then(t => expect(t).toEqual('Sign up\nSign in'))
-      .then(done, done.fail);
+  describe('Teacher Home component', () => {
+    beforeEach(() => {
+      page = new Page();
+      page.go('/teacher');
+    });
+
+    it('should have a welcome message', done => {
+      page.getTextFrom('app-teacher-home h2')
+        .then(t => expect(t).toBe('Welcome to your Teacher Portal!'))
+        .then(done, done.fail);
+    });
+
+    it('should have links to `Classes`, `Exams`, and `Profile` pages', done => {
+      page.getTextFrom('app-teacher-home nav')
+        .then(t => expect(t).toBe('Classes\nExams\nProfile'))
+        .then(done, done.fail);
+    });
+
+    it('should have shortcuts to add a class, add an exam, and edit profile', done => {
+      page.getTextFrom('app-teacher-home .content')
+        .then(t => expect(t).toBe('Add Class\nAdd Exam\nEdit Profile'))
+        .then(done, done.fail);
+    });
   });
 });

--- a/fe/src/app/app-routing.module.ts
+++ b/fe/src/app/app-routing.module.ts
@@ -1,7 +1,11 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
+import { HomeComponent } from './core/home/home.component';
+
 const routes: Routes = [
+  { path: '', pathMatch: 'full', component: HomeComponent },
+  { path: 'teacher', loadChildren: './teacher/teacher.module#TeacherModule' }
 ];
 
 @NgModule({

--- a/fe/src/app/app.module.ts
+++ b/fe/src/app/app.module.ts
@@ -3,8 +3,10 @@ import { NgModule } from '@angular/core';
 
 import { AppRoutingModule } from './app-routing.module';
 
-import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
+import { TeacherModule } from './teacher/teacher.module';
+
+import { AppComponent } from './app.component';
 
 @NgModule({
   declarations: [
@@ -13,7 +15,8 @@ import { CoreModule } from './core/core.module';
   imports: [
     BrowserModule,
     AppRoutingModule,
-    CoreModule
+    CoreModule,
+    TeacherModule
   ],
   providers: [],
   bootstrap: [ AppComponent ]

--- a/fe/src/app/core/core.module.ts
+++ b/fe/src/app/core/core.module.ts
@@ -2,16 +2,19 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { HeaderComponent } from './header/header.component';
+import { HomeComponent } from './home/home.component';
 
 @NgModule({
   imports: [
     CommonModule
   ],
   declarations: [
-    HeaderComponent
+    HeaderComponent,
+    HomeComponent
   ],
   exports: [
-    HeaderComponent
+    HeaderComponent,
+    HomeComponent
   ]
 })
 export class CoreModule {}

--- a/fe/src/app/core/header/header.component.scss
+++ b/fe/src/app/core/header/header.component.scss
@@ -62,12 +62,15 @@
     }
 
     .header-nav {
-      border-left: 2px solid white;
       grid-template-columns: repeat(2, 1fr);
 
       .link {
+        border-bottom: 2px solid $default;
+        border-top: 2px solid $default;
         text-align: center;
         padding: 20px;
+
+        @include border-radius($border-radius);
 
         &:hover {
           background-color: white;

--- a/fe/src/app/core/home/home.component.html
+++ b/fe/src/app/core/home/home.component.html
@@ -1,0 +1,3 @@
+<section class="container">
+  <h2>Please <a>Sign Up</a> or <a>Sign In</a> to get started</h2>
+</section>

--- a/fe/src/app/core/home/home.component.scss
+++ b/fe/src/app/core/home/home.component.scss
@@ -1,0 +1,10 @@
+.container {
+  margin: 0 auto;
+  padding: 10px 0;
+  width: 95%;
+
+  a:hover {
+    font-style: italic;
+    text-decoration: underline;
+  }
+}

--- a/fe/src/app/core/home/home.component.spec.ts
+++ b/fe/src/app/core/home/home.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HomeComponent } from './home.component';
+
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HomeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/fe/src/app/core/home/home.component.ts
+++ b/fe/src/app/core/home/home.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss']
+})
+export class HomeComponent implements OnInit {
+
+  constructor() {}
+
+  ngOnInit() {}
+
+}

--- a/fe/src/app/teacher/teacher-home/teacher-home.component.html
+++ b/fe/src/app/teacher/teacher-home/teacher-home.component.html
@@ -1,0 +1,31 @@
+<section class="container">
+  <h2 class="title">Welcome to your Teacher Portal!</h2>
+  <nav class="navbar">
+    <a>Classes</a>
+    <a>Exams</a>
+    <a>Profile</a>
+  </nav>
+  <div class="content">
+    <a class="box add-class" (click)="addClass()">
+      <span class="fa-stack fa-lg icons">
+        <i class="fa fa-circle-thin fa-stack-2x"></i>
+        <i class="fa fa-plus fa-stack-1x"></i>
+      </span>
+      <span>Add Class</span>
+    </a>
+    <a class="box add-exam" (click)="addExam()">
+      <span class="fa-stack fa-lg icons">
+        <i class="fa fa-circle-thin fa-stack-2x"></i>
+        <i class="fa fa-plus fa-stack-1x"></i>
+      </span>
+      <span>Add Exam</span>
+    </a>
+    <a class="box edit-profile" (click)="editProfile()">
+      <span class="fa-stack fa-lg icons">
+        <i class="fa fa-square-o fa-stack-2x"></i>
+        <i class="fa fa-pencil fa-stack-1x"></i>
+      </span>
+      <span>Edit Profile</span>
+    </a>
+  </div>
+</section>

--- a/fe/src/app/teacher/teacher-home/teacher-home.component.scss
+++ b/fe/src/app/teacher/teacher-home/teacher-home.component.scss
@@ -1,0 +1,119 @@
+@import 'colors';
+@import 'constants';
+@import 'mixins/border';
+
+.container {
+  display: grid;
+  grid-template-areas:
+    'title'
+    'nav'
+    'content';
+  margin: 0 auto;
+  padding: 10px 0;
+  width: 95%;
+
+  .title {
+    grid-area: title;
+
+    &::after {
+      border: 2px solid $default;
+      content: ' ';
+      display: block;
+
+      @include border-radius($border-radius);
+    }
+  }
+
+  .navbar {
+    display: flex;
+    grid-area: nav;
+    padding: 10px 0;
+    text-align: center;
+    flex-direction: column;
+
+    a {
+      margin: 5px auto;
+      padding: 5px;
+      width: 99%;
+
+      &:hover {
+        background-color: $default;
+        color: white;
+        font-style: italic;
+        text-decoration: underline;
+
+        @include border-radius($border-radius);
+      }
+    }
+  }
+
+  .content {
+    display: grid;
+    grid-area: content;
+    grid-template-areas:
+      'add-class'
+      'add-exam'
+      'edit-profile';
+
+    .box {
+      background-color: $default;
+      color: white;
+      margin: 5px auto;
+      padding: 50px;
+      width: 99%;
+
+      @include border-radius($border-radius * 2);
+
+      .icons {
+        display: block;
+        margin: 0 auto;
+      }
+
+      &, span:last-child {
+        text-align: center;
+      }
+    }
+
+    .add-class {
+      grid-area: add-class;
+    }
+
+    .add-exam {
+      grid-area: add-exam;
+    }
+
+    .edit-profile {
+      grid-area: edit-profile;
+    }
+  }
+}
+
+@media only screen and (min-width: 768px) {
+
+  .container {
+    grid-template-areas:
+      'title   title   title'
+      'nav     nav     nav'
+      'content content content';
+    grid-template-columns: repeat(3, 1fr);
+
+    .navbar {
+      flex-direction: row;
+
+      a {
+        margin: 5px;
+      }
+    }
+
+    .content {
+      grid-template-areas:
+        'add-class    add-exam'
+        'edit-profile edit-profile';
+
+      .edit-profile {
+        margin: 5px auto;
+      }
+    }
+  }
+
+}

--- a/fe/src/app/teacher/teacher-home/teacher-home.component.spec.ts
+++ b/fe/src/app/teacher/teacher-home/teacher-home.component.spec.ts
@@ -1,0 +1,74 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { TeacherHomeComponent } from './teacher-home.component';
+
+describe('TeacherHomeComponent', () => {
+  let component: TeacherHomeComponent;
+  let fixture: ComponentFixture<TeacherHomeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TeacherHomeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture   = TestBed.createComponent(TeacherHomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have function: `addClass`', () => {
+    expect(component.addClass.call).toBeDefined();
+  });
+
+  it('should have function: `addExam`', () => {
+    expect(component.addExam.call).toBeDefined();
+  });
+
+  it('should have function: `editProfile`', () => {
+    expect(component.editProfile.call).toBeDefined();
+  });
+
+  it('should call `addClass` when clicking shortcut link', async(() => {
+    fixture   = TestBed.createComponent(TeacherHomeComponent);
+    component = fixture.componentInstance;
+
+    const spy = spyOn(component, 'addClass');
+    const element  = fixture.debugElement;
+    const shortcut = element.query(By.css('.box.add-class'));
+    shortcut.triggerEventHandler('click', spy);
+
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  it('should call `addExam` when clicking shortcut link', async(() => {
+    fixture   = TestBed.createComponent(TeacherHomeComponent);
+    component = fixture.componentInstance;
+
+    const spy = spyOn(component, 'addExam');
+    const element  = fixture.debugElement;
+    const shortcut = element.query(By.css('.box.add-exam'));
+    shortcut.triggerEventHandler('click', spy);
+
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  it('should call `editProfile` when clicking shortcut link', async(() => {
+    fixture   = TestBed.createComponent(TeacherHomeComponent);
+    component = fixture.componentInstance;
+
+    const spy = spyOn(component, 'editProfile');
+    const element  = fixture.debugElement;
+    const shortcut = element.query(By.css('.box.edit-profile'));
+    shortcut.triggerEventHandler('click', spy);
+
+    expect(spy).toHaveBeenCalled();
+  }));
+});

--- a/fe/src/app/teacher/teacher-home/teacher-home.component.ts
+++ b/fe/src/app/teacher/teacher-home/teacher-home.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-teacher-home',
+  templateUrl: './teacher-home.component.html',
+  styleUrls: ['./teacher-home.component.scss']
+})
+export class TeacherHomeComponent implements OnInit {
+
+  constructor() {}
+
+  ngOnInit() {}
+
+  addClass() {}
+
+  addExam() {}
+
+  editProfile() {}
+
+}

--- a/fe/src/app/teacher/teacher-routing.module.ts
+++ b/fe/src/app/teacher/teacher-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { TeacherHomeComponent } from './teacher-home/teacher-home.component';
+
+const routes: Routes = [
+  { path: '', component: TeacherHomeComponent }
+];
+
+@NgModule({
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
+})
+export class TeacherRoutingModule {}

--- a/fe/src/app/teacher/teacher.module.spec.ts
+++ b/fe/src/app/teacher/teacher.module.spec.ts
@@ -1,0 +1,13 @@
+import { TeacherModule } from './teacher.module';
+
+describe('TeacherModule', () => {
+  let teacherModule: TeacherModule;
+
+  beforeEach(() => {
+    teacherModule = new TeacherModule();
+  });
+
+  it('should create an instance', () => {
+    expect(teacherModule).toBeTruthy();
+  });
+});

--- a/fe/src/app/teacher/teacher.module.ts
+++ b/fe/src/app/teacher/teacher.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { TeacherRoutingModule } from './teacher-routing.module';
+
+import { TeacherHomeComponent } from './teacher-home/teacher-home.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    TeacherRoutingModule
+  ],
+  declarations: [
+    TeacherHomeComponent
+  ],
+  exports: [
+    TeacherHomeComponent
+  ]
+})
+export class TeacherModule {}

--- a/fe/src/index.html
+++ b/fe/src/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>elle: english language learning engine</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
Add end-to-end tests and nest describe blocks inside the primary
describe block to separate end-to-end tests for each component.

Add some default routing to the application.

Add a `Home` component to the application for default unauthenticated
view.

Add a `TeacherHome` component to the apaplication for default
authenticated teacher view. This is the initial thing teachers will see
just after logging in.

Add some teacher-based routing.

Add font-awesome fonts.

Update borders on `header-nav` element (based on a suggestion) to
exclude the white border on its left side.